### PR TITLE
修复了在安卓12以上版本,打开服务崩溃的问题

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,7 +11,8 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/FileShare.iml" filepath="$PROJECT_DIR$/.idea/modules/FileShare.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/FileShare.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/FileShare.app.iml" />
-    </modules>
-  </component>
-</project>

--- a/app/src/main/java/net/newlydev/fileshare_android/MainService.java
+++ b/app/src/main/java/net/newlydev/fileshare_android/MainService.java
@@ -66,7 +66,7 @@ public class MainService extends Service
 		builder.setContentText("点击管理");
 		builder.setSmallIcon(R.mipmap.ic_launcher);
 		builder.setOngoing(true);
-		builder.setContentIntent(PendingIntent.getActivity(this,0,new Intent(this,MainActivity.class),0));
+		builder.setContentIntent(PendingIntent.getActivity(this, 0, new Intent(this, MainActivity.class), PendingIntent.FLAG_IMMUTABLE));
 	}
 	
 	@Override


### PR DESCRIPTION
Android 版本 S+（31及以上版本）时，创建 PendingIntent 时需要指定 FLAG_IMMUTABLE 或 FLAG_MUTABLE 中的一个，改为了FLAG_IMMUTABLE